### PR TITLE
OpenBSD/amd64 6.3 to 6.5 Upgrade Instructions.

### DIFF
--- a/data/docs/openbsd/upgrade-63-to-65.html
+++ b/data/docs/openbsd/upgrade-63-to-65.html
@@ -44,7 +44,114 @@
 </table>
 <h1>Upgrade OpenBSD 6.3 to 6.5</h1><h3>OpenBSD/amd64 6.3 to 6.5 Upgrade Instructions</h3><p>As clearly stated in the OpenBSD FAQ regarding upgrading one release to another, <em>upgrades are only supported from one release to the release immediately following it</em>. So what to do if it needs to upgrade the 6.3 release of OpenBSD to the 6.5 release is to upgrade sequentially, first to the 6.4 release, and then to the 6.5 release.</p>
 <p><strong>Upgrade OpenBSD 6.3 release to 6.4 release</strong></p>
-<p>TBD.</p>
+<p>Having installed and running the OpenBSD/amd64 6.3 release first of all it needs to download the new (6.4) ramdisk kernel <code>bsd.rd</code> and the checksum file <code>SHA256.sig</code> for the appropriate architecture, in this case <code>amd64</code>:</p>
+<pre><code>$ curl -sO https://cdn.openbsd.org/pub/OpenBSD/6.4/amd64/bsd.rd     \
+       -sO https://cdn.openbsd.org/pub/OpenBSD/6.4/amd64/SHA256.sig</code></pre><p>Verify checksum of the new ramdisk kernel:</p>
+<pre><code>$ signify -C -p /etc/signify/openbsd-64-base.pub -x SHA256.sig bsd.rd
+Signature Verified
+bsd.rd: OK</code></pre><p>Permanently set the new CDN URL (it was changed in the 6.4 release) which will be used during system upgrade and later on during upgrading the packages:</p>
+<pre><code>$ cat /etc/installurl
+https://ftp.openbsd.org/pub/OpenBSD    &lt;== The old one.
+$
+$ sudo su -
+# echo &quot;https://cdn.openbsd.org/pub/OpenBSD&quot; &gt; /etc/installurl
+$
+$ cat /etc/installurl
+https://cdn.openbsd.org/pub/OpenBSD    &lt;== The new one.</code></pre><p>Remove unneeded (unused) files:</p>
+<pre><code>$ sudo rm -vf /dev/audio /dev/audioctl
+/dev/audio
+/dev/audioctl
+$
+$ sudo rm -vf /etc/rc.d/rtadvd /usr/sbin/rtadvd \
+              /usr/share/man/man5/rtadvd.conf.5 \
+              /usr/share/man/man8/rtadvd.8
+/etc/rc.d/rtadvd
+/usr/sbin/rtadvd
+/usr/share/man/man5/rtadvd.conf.5
+/usr/share/man/man8/rtadvd.8
+$
+$ sudo rm -vf /usr/X11R6/lib/libxcb-xevie.*          \
+              /usr/X11R6/lib/libxcb-xprint.*         \
+              /usr/X11R6/lib/pkgconfig/xcb-xevie.pc  \
+              /usr/X11R6/lib/pkgconfig/xcb-xprint.pc
+/usr/X11R6/lib/libxcb-xevie.a
+/usr/X11R6/lib/libxcb-xevie.so.1.0
+/usr/X11R6/lib/libxcb-xprint.a
+/usr/X11R6/lib/libxcb-xprint.so.3.0
+/usr/X11R6/lib/pkgconfig/xcb-xevie.pc
+/usr/X11R6/lib/pkgconfig/xcb-xprint.pc</code></pre><p>Remove unneeded (unused) user and group:</p>
+<pre><code>$ sudo userdel _rtadvd &amp;&amp; sudo groupdel _rtadvd</code></pre><p>Disable starting up the <code>buildslave</code> (obsolete) daemon:</p>
+<pre><code>$ sudo rcctl disable buildslave</code></pre><p>Copy the new ramdisk kernel to the root filesystem:</p>
+<pre><code>$ sudo cp -vf bsd.rd /
+bsd.rd -&gt; /bsd.rd</code></pre><p><strong>== IT&#39;S THE TIME TO BOOT INTO THE NEW KERNEL ==</strong></p>
+<p>Reboot:</p>
+<pre><code>$ sudo shutdown -r now</code></pre><p>At the boot loader prompt type <code>bsd.rd</code> and hit <code>&lt;Enter&gt;</code>:</p>
+<pre><code>boot&gt; bsd.rd</code></pre><p>After the kernel is booted, hit <code>s</code> (that means <code>(S)hell</code>) to enter the shell to configure network if not already autoconfigured. In the shell make necessary network configuration, then hit <code>&lt;Ctrl-D&gt;</code> to return to the installation/upgrading program. (This step is very important if, for example, the OpenBSD box is installed and running as a virtual machine, like <a href="https://github.com/rgolubtsov/dotfiles/blob/master/openbsd/README.md" title="OpenBSD VM-boxes using QEMU">this one</a>):</p>
+<pre><code># ifconfig vio0 10.0.2.101/24
+# route add default 10.0.2.1
+add net default: gateway 10.0.2.1
+# ^D</code></pre><p>Hit <code>u</code> (that means <code>(U)pgrade</code>) and follow sequential prompts. In most cases for most questions just hit <code>&lt;Enter&gt;</code> for default choices.</p>
+<p>After reboot into the upgraded system...</p>
+<pre><code>OpenBSD 6.4 (GENERIC.MP) #364: Thu Oct 11 13:30:23 MDT 2018
+
+Welcome to OpenBSD: The proactively secure Unix-like operating system.
+
+Please use the sendbug(1) utility to report bugs in the system.
+Before reporting a bug, please try to reproduce it with the latest
+version of the code.  With bug reports, please try to ensure that
+enough information to reproduce the problem is enclosed, and if a
+known fix for it exists, include that as well.</code></pre><p>...and making initial network configuration...</p>
+<pre><code>$ sudo ifconfig vio0 10.0.2.101/24
+$ sudo route add default 10.0.2.1
+add net default: gateway 10.0.2.1</code></pre><p>...upgrade the packages:</p>
+<pre><code>$ sudo pkg_add -uv
+Update candidates: quirks-2.414 -&gt; quirks-3.16
+quirks-3.16 signed on 2018-10-12T15:26:25Z
+quirks-2.414-&gt;3.16: ok
+Update candidates: adwaita-icon-theme-3.26.1 -&gt; adwaita-icon-theme-3.28.0p1
+Update candidates: gtk-update-icon-cache-3.22.29 -&gt; gtk-update-icon-cache-3.22.30p1
+Update candidates: hicolor-icon-theme-0.17 -&gt; hicolor-icon-theme-0.17
+...
+Running tags: ok
+Read shared items: ok
+...
+Obsolete package: mozjs17-17.0p4 (no longer maintained and full of security holes)
+Couldn&#39;t find updates for mozjs17-17.0p4
+Extracted 2124668768 from 2265411565</code></pre><p>Make all the necessary removals and updates which were reported by the <code>pkg_add</code> command:</p>
+<pre><code>$ sudo rm -f /var/db/colord/mapping.db \
+             /var/db/colord/storage.db
+$
+$ sudo rm -rf /etc/dconf/db/*      \
+              /etc/dconf/profile/*
+$
+$ sudo rm -Rf /usr/local/lib/gcc/x86_64-unknown-openbsd6.3/
+$
+$ sudo rm -Rf /usr/local/share/mime/x-epoc/      \
+              /usr/local/share/mime/x-content/   \
+              /usr/local/share/mime/video/       \
+              /usr/local/share/mime/text/        \
+              /usr/local/share/mime/multipart/   \
+              /usr/local/share/mime/model/       \
+              /usr/local/share/mime/message/     \
+              /usr/local/share/mime/inode/       \
+              /usr/local/share/mime/image/       \
+              /usr/local/share/mime/font/        \
+              /usr/local/share/mime/audio/       \
+              /usr/local/share/mime/application/
+$
+$ sudo xmlcatalog /var/db/xmlcatalog
+$
+$ sudo update-desktop-database
+$
+$ sudo update-mime-database /usr/local/share/mime/
+$
+$ sudo pkg_delete -v mozjs17
+mozjs17-17.0p4: ok
+Read shared items: ok</code></pre><p>Remove previously downloaded and already unneeded ramdisk kernel and its checksum file which reside in the user home directory:</p>
+<pre><code>$ rm -vf bsd.rd SHA256.sig 
+bsd.rd
+SHA256.sig</code></pre><p><strong>== OPENBSD HAS BEEN UPGRADED TO THE 6.4 RELEASE ==</strong></p>
+<p><img src="http://github.githubassets.com/images/icons/emoji/unicode/1f603.png" class="emoji" alt="" /></p>
 <p><strong>Upgrade OpenBSD 6.4 release to 6.5 release</strong></p>
 <p>TBD.</p>
 <p>Freshly <strong>OpenBSD</strong>-ing your beings ! <img src="http://github.githubassets.com/images/icons/emoji/unicode/1f44d.png" class="emoji" alt="" /></p>

--- a/data/docs/openbsd/upgrade-63-to-65.html
+++ b/data/docs/openbsd/upgrade-63-to-65.html
@@ -1,0 +1,56 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+<head>
+<meta http-equiv="Content-Type"    content="text/html; charset=UTF-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta       name="viewport"        content="width=device-width,initial-scale=1" />
+<meta       name="description"     content="A personal website of a power looper, a skateboarder, and a coder" />
+<meta       name="author"          content="Radislav (Radicchio) Golubtsov" />
+<meta       name="copyright"       content="Copyright (C) 2016-2019 Radislav (Radicchio) Golubtsov" />
+<title>A Cup of Radicchio: Upgrade OpenBSD 6.3 to 6.5</title>
+<link href="/radicchio.css" type="text/css"  rel="stylesheet" media="screen" />
+<link href="/favicon.ico"   type="image/png" rel="icon" />
+</head>
+<body id="radicchio">
+<table id="header">
+<tbody>
+<tr id="title">
+<td rowspan="2" id="v-bar-h"></td>
+<td id="title-td">A Cup of Radicchio: Upgrade OpenBSD 6.3 to 6.5<br />
+<span id="subtitle">A personal website of a power looper, a skateboarder, and a coder</span></td>
+</tr>
+<tr id="navbar">
+<td id="navbar-td"><a href="/">&nbsp;Home&nbsp;</a><a href="/data/docs">&nbsp;Docs&nbsp;</a><a href="/data/srcs">&nbsp;Sources&nbsp;</a><a href="/data/blog">&nbsp;Blog&nbsp;</a><a href="https://github.com/rgolubtsov">&nbsp;GitHub&nbsp;</a></td>
+</tr>
+</tbody>
+</table>
+<h1>Upgrade OpenBSD 6.3 to 6.5</h1><h3>OpenBSD/amd64 6.3 to 6.5 Upgrade Instructions</h3><p>As clearly stated in the OpenBSD FAQ regarding upgrading one release to another, <em>upgrades are only supported from one release to the release immediately following it</em>. So what to do if it needs to upgrade the 6.3 release of OpenBSD to the 6.5 release is to upgrade sequentially, first to the 6.4 release, and then to the 6.5 release.</p>
+<p><strong>Upgrade OpenBSD 6.3 release to 6.4 release</strong></p>
+<p>TBD.</p>
+<p><strong>Upgrade OpenBSD 6.4 release to 6.5 release</strong></p>
+<p>TBD.</p>
+<p>Freshly <strong>OpenBSD</strong>-ing your beings ! <img src="http://github.githubassets.com/images/icons/emoji/unicode/1f44d.png" class="emoji" alt="" /></p>
+<table id="footer">
+<tbody><tr><td id="v-bar-f"></td><td id="footer-td"><a href="http://anybrowser.org/campaign"><img style="border:0;width:88px;height:31px" src="/static/img/misc/vwab" alt="Viewable With Any Browser" /></a><a href="http://jigsaw.w3.org/css-validator/check/referer"><img style="border:0;width:88px;height:31px" src="/static/img/misc/vcss" alt="Valid CSS!" /></a></td></tr></tbody>
+</table>
+</body>
+</html>
+

--- a/data/docs/openbsd/upgrade-63-to-65.html
+++ b/data/docs/openbsd/upgrade-63-to-65.html
@@ -44,12 +44,12 @@
 </table>
 <h1>Upgrade OpenBSD 6.3 to 6.5</h1><h3>OpenBSD/amd64 6.3 to 6.5 Upgrade Instructions</h3><p>As clearly stated in the OpenBSD FAQ regarding upgrading one release to another, <em>upgrades are only supported from one release to the release immediately following it</em>. So what to do if it needs to upgrade the 6.3 release of OpenBSD to the 6.5 release is to upgrade sequentially, first to the 6.4 release, and then to the 6.5 release.</p>
 <p><strong>Upgrade OpenBSD 6.3 release to 6.4 release</strong></p>
-<p>Having installed and running the OpenBSD/amd64 6.3 release first of all it needs to download the new (6.4) ramdisk kernel <code>bsd.rd</code> and the checksum file <code>SHA256.sig</code> for the appropriate architecture, in this case <code>amd64</code>:</p>
+<p><strong>(a)</strong> Having installed and running the OpenBSD/amd64 6.3 release, first of all it needs to download the new (6.4) ramdisk kernel <code>bsd.rd</code> and the checksum file <code>SHA256.sig</code> for the appropriate architecture, in this case <code>amd64</code>:</p>
 <pre><code>$ curl -sO https://cdn.openbsd.org/pub/OpenBSD/6.4/amd64/bsd.rd     \
-       -sO https://cdn.openbsd.org/pub/OpenBSD/6.4/amd64/SHA256.sig</code></pre><p>Verify checksum of the new ramdisk kernel:</p>
+       -sO https://cdn.openbsd.org/pub/OpenBSD/6.4/amd64/SHA256.sig</code></pre><p><strong>(b)</strong> Verify checksum of the new ramdisk kernel:</p>
 <pre><code>$ signify -C -p /etc/signify/openbsd-64-base.pub -x SHA256.sig bsd.rd
 Signature Verified
-bsd.rd: OK</code></pre><p>Permanently set the new CDN URL (it was changed in the 6.4 release) which will be used during system upgrade and later on during upgrading the packages:</p>
+bsd.rd: OK</code></pre><p><strong>(c)</strong> Permanently set the new CDN URL (it was changed in the 6.4 release) which will be using during system upgrade and later on during upgrading the packages:</p>
 <pre><code>$ cat /etc/installurl
 https://ftp.openbsd.org/pub/OpenBSD    &lt;== The old one.
 $
@@ -57,7 +57,7 @@ $ sudo su -
 # echo &quot;https://cdn.openbsd.org/pub/OpenBSD&quot; &gt; /etc/installurl
 $
 $ cat /etc/installurl
-https://cdn.openbsd.org/pub/OpenBSD    &lt;== The new one.</code></pre><p>Remove unneeded (unused) files:</p>
+https://cdn.openbsd.org/pub/OpenBSD    &lt;== The new one.</code></pre><p><strong>(d)</strong> Remove unneeded (unused) files:</p>
 <pre><code>$ sudo rm -vf /dev/audio /dev/audioctl
 /dev/audio
 /dev/audioctl
@@ -79,18 +79,18 @@ $ sudo rm -vf /usr/X11R6/lib/libxcb-xevie.*          \
 /usr/X11R6/lib/libxcb-xprint.a
 /usr/X11R6/lib/libxcb-xprint.so.3.0
 /usr/X11R6/lib/pkgconfig/xcb-xevie.pc
-/usr/X11R6/lib/pkgconfig/xcb-xprint.pc</code></pre><p>Remove unneeded (unused) user and group:</p>
-<pre><code>$ sudo userdel _rtadvd &amp;&amp; sudo groupdel _rtadvd</code></pre><p>Disable starting up the <code>buildslave</code> (obsolete) daemon:</p>
-<pre><code>$ sudo rcctl disable buildslave</code></pre><p>Copy the new ramdisk kernel to the root filesystem:</p>
+/usr/X11R6/lib/pkgconfig/xcb-xprint.pc</code></pre><p><strong>(e)</strong> Remove unneeded (unused) user and group:</p>
+<pre><code>$ sudo userdel _rtadvd &amp;&amp; sudo groupdel _rtadvd</code></pre><p><strong>(f)</strong> Disable starting up the <code>buildslave</code> (obsolete) daemon:</p>
+<pre><code>$ sudo rcctl disable buildslave</code></pre><p><strong>(g)</strong> Copy the new ramdisk kernel to the root filesystem:</p>
 <pre><code>$ sudo cp -vf bsd.rd /
 bsd.rd -&gt; /bsd.rd</code></pre><p><strong>== IT&#39;S THE TIME TO BOOT INTO THE NEW KERNEL ==</strong></p>
-<p>Reboot:</p>
-<pre><code>$ sudo shutdown -r now</code></pre><p>At the boot loader prompt type <code>bsd.rd</code> and hit <code>&lt;Enter&gt;</code>:</p>
-<pre><code>boot&gt; bsd.rd</code></pre><p>After the kernel is booted, hit <code>s</code> (that means <code>(S)hell</code>) to enter the shell to configure network if not already autoconfigured. In the shell make necessary network configuration, then hit <code>&lt;Ctrl-D&gt;</code> to return to the installation/upgrading program. (This step is very important if, for example, the OpenBSD box is installed and running as a virtual machine, like <a href="https://github.com/rgolubtsov/dotfiles/blob/master/openbsd/README.md" title="OpenBSD VM-boxes using QEMU">this one</a>):</p>
+<p><strong>(h)</strong> Reboot:</p>
+<pre><code>$ sudo shutdown -r now</code></pre><p><strong>(i)</strong> At the boot loader prompt type <code>bsd.rd</code> and hit <code>&lt;Enter&gt;</code>:</p>
+<pre><code>boot&gt; bsd.rd</code></pre><p><strong>(j)</strong> After the kernel is booted, hit <code>s</code> (that means <code>(S)hell</code>) to enter the shell to configure network if not already autoconfigured. In the shell make necessary network configuration, then hit <code>&lt;Ctrl-D&gt;</code> to return to the installation/upgrading program. (This step is very important if, for example, the OpenBSD box is installed and running as a virtual machine, like <a href="https://github.com/rgolubtsov/dotfiles/blob/master/openbsd/README.md" title="OpenBSD VM-boxes using QEMU">this one</a>):</p>
 <pre><code># ifconfig vio0 10.0.2.101/24
 # route add default 10.0.2.1
 add net default: gateway 10.0.2.1
-# ^D</code></pre><p>Hit <code>u</code> (that means <code>(U)pgrade</code>) and follow sequential prompts. In most cases for most questions just hit <code>&lt;Enter&gt;</code> for default choices.</p>
+# ^D</code></pre><p><strong>(k)</strong> Hit <code>u</code> (that means <code>(U)pgrade</code>) and follow sequential prompts. In most cases for most questions just hit <code>&lt;Enter&gt;</code> for default choices.</p>
 <p>After reboot into the upgraded system...</p>
 <pre><code>OpenBSD 6.4 (GENERIC.MP) #364: Thu Oct 11 13:30:23 MDT 2018
 
@@ -117,7 +117,7 @@ Read shared items: ok
 ...
 Obsolete package: mozjs17-17.0p4 (no longer maintained and full of security holes)
 Couldn&#39;t find updates for mozjs17-17.0p4
-Extracted 2124668768 from 2265411565</code></pre><p>Make all the necessary removals and updates which were reported by the <code>pkg_add</code> command:</p>
+Extracted 2124668768 from 2265411565</code></pre><p><strong>(l)</strong> Make all the necessary removals and updates which were reported by the <code>pkg_add</code> command:</p>
 <pre><code>$ sudo rm -f /var/db/colord/mapping.db \
              /var/db/colord/storage.db
 $
@@ -147,13 +147,128 @@ $ sudo update-mime-database /usr/local/share/mime/
 $
 $ sudo pkg_delete -v mozjs17
 mozjs17-17.0p4: ok
-Read shared items: ok</code></pre><p>Remove previously downloaded and already unneeded ramdisk kernel and its checksum file which reside in the user home directory:</p>
-<pre><code>$ rm -vf bsd.rd SHA256.sig 
+Read shared items: ok</code></pre><p><strong>(m)</strong> Remove previously downloaded and already unneeded ramdisk kernel and its checksum file which reside in the user home directory:</p>
+<pre><code>$ rm -vf bsd.rd SHA256.sig
 bsd.rd
 SHA256.sig</code></pre><p><strong>== OPENBSD HAS BEEN UPGRADED TO THE 6.4 RELEASE ==</strong></p>
 <p><img src="http://github.githubassets.com/images/icons/emoji/unicode/1f603.png" class="emoji" alt="" /></p>
 <p><strong>Upgrade OpenBSD 6.4 release to 6.5 release</strong></p>
-<p>TBD.</p>
+<p>Now having installed and running the OpenBSD/amd64 6.4 release, there is a need to download the new (6.5) ramdisk kernel <code>bsd.rd</code> and the checksum file <code>SHA256.sig</code> for the appropriate architecture, in this case <code>amd64</code>, just like as it is stated in the beginning of the previous section &ndash; subsection <strong>(a)</strong>:</p>
+<pre><code>$ curl -sO https://cdn.openbsd.org/pub/OpenBSD/6.5/amd64/bsd.rd     \
+       -sO https://cdn.openbsd.org/pub/OpenBSD/6.5/amd64/SHA256.sig</code></pre><p>Verify checksum of the new ramdisk kernel:</p>
+<pre><code>$ signify -C -p /etc/signify/openbsd-65-base.pub -x SHA256.sig bsd.rd
+Signature Verified
+bsd.rd: OK</code></pre><p>Remove unneeded (unused) files:</p>
+<pre><code>$ sudo rm -vf /usr/include/openssl/asn1_mac.h
+/usr/include/openssl/asn1_mac.h
+$
+$ sudo rm -vf /usr/bin/c2ph                                      \
+              /usr/bin/pstruct                                   \
+              /usr/libdata/perl5/Locale/Codes/API.pod            \
+              /usr/libdata/perl5/Module/CoreList/TieHashDelta.pm \
+              /usr/libdata/perl5/Unicode/Collate/Locale/bg.pl    \
+              /usr/libdata/perl5/Unicode/Collate/Locale/fr.pl    \
+              /usr/libdata/perl5/Unicode/Collate/Locale/ru.pl    \
+              /usr/libdata/perl5/unicore/lib/Sc/Cham.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Ethi.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Hebr.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Hmng.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Khar.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Khmr.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Lana.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Lao.pl           \
+              /usr/libdata/perl5/unicore/lib/Sc/Talu.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Tibt.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Xsux.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Zzzz.pl          \
+              /usr/share/man/man1/c2ph.1                         \
+              /usr/share/man/man1/pstruct.1                      \
+              /usr/share/man/man3p/Locale::Codes::API.3p
+/usr/bin/c2ph
+/usr/bin/pstruct
+/usr/libdata/perl5/Locale/Codes/API.pod
+/usr/libdata/perl5/Module/CoreList/TieHashDelta.pm
+/usr/libdata/perl5/Unicode/Collate/Locale/bg.pl
+/usr/libdata/perl5/Unicode/Collate/Locale/fr.pl
+/usr/libdata/perl5/Unicode/Collate/Locale/ru.pl
+/usr/libdata/perl5/unicore/lib/Sc/Cham.pl
+/usr/libdata/perl5/unicore/lib/Sc/Ethi.pl
+/usr/libdata/perl5/unicore/lib/Sc/Hebr.pl
+/usr/libdata/perl5/unicore/lib/Sc/Hmng.pl
+/usr/libdata/perl5/unicore/lib/Sc/Khar.pl
+/usr/libdata/perl5/unicore/lib/Sc/Khmr.pl
+/usr/libdata/perl5/unicore/lib/Sc/Lana.pl
+/usr/libdata/perl5/unicore/lib/Sc/Lao.pl
+/usr/libdata/perl5/unicore/lib/Sc/Talu.pl
+/usr/libdata/perl5/unicore/lib/Sc/Tibt.pl
+/usr/libdata/perl5/unicore/lib/Sc/Xsux.pl
+/usr/libdata/perl5/unicore/lib/Sc/Zzzz.pl
+/usr/share/man/man1/c2ph.1
+/usr/share/man/man1/pstruct.1
+/usr/share/man/man3p/Locale::Codes::API.3p</code></pre><p>Perform actions from the previous section &ndash; subsections <strong>(g)</strong> to <strong>(k)</strong>, then:</p>
+<p>After reboot into the upgraded system...</p>
+<pre><code>OpenBSD 6.5 (GENERIC.MP) #3: Sat Apr 13 14:48:43 MDT 2019
+
+Welcome to OpenBSD: The proactively secure Unix-like operating system.
+
+Please use the sendbug(1) utility to report bugs in the system.
+Before reporting a bug, please try to reproduce it with the latest
+version of the code.  With bug reports, please try to ensure that
+enough information to reproduce the problem is enclosed, and if a
+known fix for it exists, include that as well.</code></pre><p>...and making initial network configuration...</p>
+<pre><code>$ sudo ifconfig vio0 10.0.2.101/24
+$ sudo route add default 10.0.2.1
+add net default: gateway 10.0.2.1</code></pre><p>...it&#39;s the time to upgrade the packages: <code>$ sudo pkg_add -uv</code>; but first check the package database:</p>
+<pre><code>$ pkg_info
+perl:/usr/local/libdata/perl5/site_perl/amd64-openbsd/auto/Cwd/Cwd.so: undefined symbol &#39;PL_sv_undef&#39;
+Can&#39;t load &#39;/usr/local/libdata/perl5/site_perl/amd64-openbsd/auto/Cwd/Cwd.so&#39; for module Cwd: Cannot load specified object at /usr/local/libdata/perl5/site_perl/amd64-openbsd/XSLoader.pm line 96.
+ at /usr/local/libdata/perl5/site_perl/amd64-openbsd/Cwd.pm line 82.
+Compilation failed in require at /usr/local/libdata/perl5/site_perl/amd64-openbsd/File/Spec/Unix.pm line 4.
+BEGIN failed--compilation aborted at /usr/local/libdata/perl5/site_perl/amd64-openbsd/File/Spec/Unix.pm line 4.
+Compilation failed in require at /usr/local/libdata/perl5/site_perl/amd64-openbsd/File/Spec.pm line 21.
+Compilation failed in require at /usr/libdata/perl5/OpenBSD/PackageInfo.pm line 168.</code></pre><p>The command above doesn&#39;t work, and as it is clearly seeing in the output, something gets wrong with the Perl module <code>Cwd</code>. But further investigations show out that this module (as being an XS-module) was compiled to use with the previous version of Perl, hence it is incompatible with the currently installed Perl release.</p>
+<p>Obviously, the easiest solution to repair this crucial Perl module is to replace the whole Perl base module set with that one freshly downloaded from the OpenBSD CDN. It is contained in the <code>base65.tgz</code> tarball. The following compound one-liner command will replace the old Perl base module set with the new one with minimal effort from the user side:</p>
+<pre><code>$ mkdir        xyz                                                                                  &amp;&amp; \
+  cd           xyz/                                                                                 &amp;&amp; \
+  curl    -sO  https://cdn.openbsd.org/pub/OpenBSD/6.5/amd64/base65.tgz                             &amp;&amp; \
+  tar     -xzf base65.tgz                                                                           &amp;&amp; \
+  sudo rm -Rf  /usr/local/libdata/perl5/site_perl/amd64-openbsd/*                                   &amp;&amp; \
+  sudo cp -Rf ./usr/libdata/perl5/amd64-openbsd/* /usr/local/libdata/perl5/site_perl/amd64-openbsd/ &amp;&amp; \
+  cd -                                                                                              &amp;&amp; \
+  sudo rm -Rf  xyz/</code></pre><p>Now package-manipulation commands (<code>pkg_info</code>, <code>pkg_add</code>, <code>pkg_delete</code>, etc.) should be working fine:</p>
+<pre><code>$ pkg_info
+adwaita-icon-theme-3.28.0p1 base icon theme for GNOME
+at-spi2-atk-2.26.2  atk-bridge for at-spi2
+at-spi2-core-2.28.0p0 service interface for assistive technologies
+...
+xz-5.2.4            LZMA compression and decompression tools
+zip-3.0p0           create/update ZIP files compatible with PKZip(tm)
+zstd-1.3.5p0        zstandard fast real-time compression algorithm</code></pre><p>Upgrade the packages:</p>
+<pre><code>$ sudo pkg_add -uv
+Update candidates: quirks-3.16 -&gt; quirks-3.124
+quirks-3.124 signed on 2019-04-15T12:10:16Z
+quirks-3.16-&gt;3.124: ok
+Update candidates: adwaita-icon-theme-3.28.0p1 -&gt; adwaita-icon-theme-3.30.1
+Update candidates: gtk-update-icon-cache-3.22.30p1 -&gt; gtk-update-icon-cache-3.24.7
+Update candidates: gdk-pixbuf-2.36.12 -&gt; gdk-pixbuf-2.38.1
+...
+Running tags: ok
+Read shared items: ok
+...
+Couldn&#39;t find updates for rebar19-2.6.2p0
+Extracted 2530483626 from 2530564521</code></pre><p>Make all the necessary removals and updates which were reported by the <code>pkg_add</code> command:</p>
+<pre><code>$ sudo rm -f /var/db/colord/mapping.db \
+             /var/db/colord/storage.db
+$
+$ sudo rm -rf /etc/dconf/db/*      \
+              /etc/dconf/profile/*
+$
+$ sudo xmlcatalog /var/db/xmlcatalog
+$
+$ sudo update-desktop-database
+$
+$ sudo update-mime-database /usr/local/share/mime/</code></pre><p>Perform the action from the previous section, subsection <strong>(m)</strong>.</p>
+<p><strong>== OPENBSD HAS BEEN UPGRADED TO THE 6.5 RELEASE ==</strong></p>
 <p>Freshly <strong>OpenBSD</strong>-ing your beings ! <img src="http://github.githubassets.com/images/icons/emoji/unicode/1f44d.png" class="emoji" alt="" /></p>
 <table id="footer">
 <tbody><tr><td id="v-bar-f"></td><td id="footer-td"><a href="http://anybrowser.org/campaign"><img style="border:0;width:88px;height:31px" src="/static/img/misc/vwab" alt="Viewable With Any Browser" /></a><a href="http://jigsaw.w3.org/css-validator/check/referer"><img style="border:0;width:88px;height:31px" src="/static/img/misc/vcss" alt="Valid CSS!" /></a></td></tr></tbody>

--- a/src/data/docs/openbsd/_data.json
+++ b/src/data/docs/openbsd/_data.json
@@ -1,0 +1,7 @@
+{
+    "upgrade-63-to-65" : {
+        "layout"       : "../../../_radicchio",
+        "sitename_"    : ": Upgrade OpenBSD 6.3 to 6.5",
+        "subtitle_"    : ""
+    }
+}

--- a/src/data/docs/openbsd/upgrade-63-to-65.md
+++ b/src/data/docs/openbsd/upgrade-63-to-65.md
@@ -6,14 +6,14 @@ As clearly stated in the OpenBSD FAQ regarding upgrading one release to another,
 
 **Upgrade OpenBSD 6.3 release to 6.4 release**
 
-Having installed and running the OpenBSD/amd64 6.3 release first of all it needs to download the new (6.4) ramdisk kernel `bsd.rd` and the checksum file `SHA256.sig` for the appropriate architecture, in this case `amd64`:
+**(a)** Having installed and running the OpenBSD/amd64 6.3 release, first of all it needs to download the new (6.4) ramdisk kernel `bsd.rd` and the checksum file `SHA256.sig` for the appropriate architecture, in this case `amd64`:
 
 ```
 $ curl -sO https://cdn.openbsd.org/pub/OpenBSD/6.4/amd64/bsd.rd     \
        -sO https://cdn.openbsd.org/pub/OpenBSD/6.4/amd64/SHA256.sig
 ```
 
-Verify checksum of the new ramdisk kernel:
+**(b)** Verify checksum of the new ramdisk kernel:
 
 ```
 $ signify -C -p /etc/signify/openbsd-64-base.pub -x SHA256.sig bsd.rd
@@ -21,7 +21,7 @@ Signature Verified
 bsd.rd: OK
 ```
 
-Permanently set the new CDN URL (it was changed in the 6.4 release) which will be used during system upgrade and later on during upgrading the packages:
+**(c)** Permanently set the new CDN URL (it was changed in the 6.4 release) which will be using during system upgrade and later on during upgrading the packages:
 
 ```
 $ cat /etc/installurl
@@ -34,7 +34,7 @@ $ cat /etc/installurl
 https://cdn.openbsd.org/pub/OpenBSD    <== The new one.
 ```
 
-Remove unneeded (unused) files:
+**(d)** Remove unneeded (unused) files:
 
 ```
 $ sudo rm -vf /dev/audio /dev/audioctl
@@ -61,19 +61,19 @@ $ sudo rm -vf /usr/X11R6/lib/libxcb-xevie.*          \
 /usr/X11R6/lib/pkgconfig/xcb-xprint.pc
 ```
 
-Remove unneeded (unused) user and group:
+**(e)** Remove unneeded (unused) user and group:
 
 ```
 $ sudo userdel _rtadvd && sudo groupdel _rtadvd
 ```
 
-Disable starting up the `buildslave` (obsolete) daemon:
+**(f)** Disable starting up the `buildslave` (obsolete) daemon:
 
 ```
 $ sudo rcctl disable buildslave
 ```
 
-Copy the new ramdisk kernel to the root filesystem:
+**(g)** Copy the new ramdisk kernel to the root filesystem:
 
 ```
 $ sudo cp -vf bsd.rd /
@@ -82,19 +82,19 @@ bsd.rd -> /bsd.rd
 
 **== IT'S THE TIME TO BOOT INTO THE NEW KERNEL ==**
 
-Reboot:
+**(h)** Reboot:
 
 ```
 $ sudo shutdown -r now
 ```
 
-At the boot loader prompt type `bsd.rd` and hit `<Enter>`:
+**(i)** At the boot loader prompt type `bsd.rd` and hit `<Enter>`:
 
 ```
 boot> bsd.rd
 ```
 
-After the kernel is booted, hit `s` (that means `(S)hell`) to enter the shell to configure network if not already autoconfigured. In the shell make necessary network configuration, then hit `<Ctrl-D>` to return to the installation/upgrading program. (This step is very important if, for example, the OpenBSD box is installed and running as a virtual machine, like [this one](https://github.com/rgolubtsov/dotfiles/blob/master/openbsd/README.md "OpenBSD VM-boxes using QEMU")):
+**(j)** After the kernel is booted, hit `s` (that means `(S)hell`) to enter the shell to configure network if not already autoconfigured. In the shell make necessary network configuration, then hit `<Ctrl-D>` to return to the installation/upgrading program. (This step is very important if, for example, the OpenBSD box is installed and running as a virtual machine, like [this one](https://github.com/rgolubtsov/dotfiles/blob/master/openbsd/README.md "OpenBSD VM-boxes using QEMU")):
 
 ```
 # ifconfig vio0 10.0.2.101/24
@@ -103,7 +103,7 @@ add net default: gateway 10.0.2.1
 # ^D
 ```
 
-Hit `u` (that means `(U)pgrade`) and follow sequential prompts. In most cases for most questions just hit `<Enter>` for default choices.
+**(k)** Hit `u` (that means `(U)pgrade`) and follow sequential prompts. In most cases for most questions just hit `<Enter>` for default choices.
 
 After reboot into the upgraded system...
 
@@ -146,7 +146,7 @@ Couldn't find updates for mozjs17-17.0p4
 Extracted 2124668768 from 2265411565
 ```
 
-Make all the necessary removals and updates which were reported by the `pkg_add` command:
+**(l)** Make all the necessary removals and updates which were reported by the `pkg_add` command:
 
 ```
 $ sudo rm -f /var/db/colord/mapping.db \
@@ -181,10 +181,10 @@ mozjs17-17.0p4: ok
 Read shared items: ok
 ```
 
-Remove previously downloaded and already unneeded ramdisk kernel and its checksum file which reside in the user home directory:
+**(m)** Remove previously downloaded and already unneeded ramdisk kernel and its checksum file which reside in the user home directory:
 
 ```
-$ rm -vf bsd.rd SHA256.sig 
+$ rm -vf bsd.rd SHA256.sig
 bsd.rd
 SHA256.sig
 ```
@@ -195,6 +195,173 @@ SHA256.sig
 
 **Upgrade OpenBSD 6.4 release to 6.5 release**
 
-TBD.
+Now having installed and running the OpenBSD/amd64 6.4 release, there is a need to download the new (6.5) ramdisk kernel `bsd.rd` and the checksum file `SHA256.sig` for the appropriate architecture, in this case `amd64`, just like as it is stated in the beginning of the previous section &ndash; subsection **(a)**:
+
+```
+$ curl -sO https://cdn.openbsd.org/pub/OpenBSD/6.5/amd64/bsd.rd     \
+       -sO https://cdn.openbsd.org/pub/OpenBSD/6.5/amd64/SHA256.sig
+```
+
+Verify checksum of the new ramdisk kernel:
+
+```
+$ signify -C -p /etc/signify/openbsd-65-base.pub -x SHA256.sig bsd.rd
+Signature Verified
+bsd.rd: OK
+```
+
+Remove unneeded (unused) files:
+
+```
+$ sudo rm -vf /usr/include/openssl/asn1_mac.h
+/usr/include/openssl/asn1_mac.h
+$
+$ sudo rm -vf /usr/bin/c2ph                                      \
+              /usr/bin/pstruct                                   \
+              /usr/libdata/perl5/Locale/Codes/API.pod            \
+              /usr/libdata/perl5/Module/CoreList/TieHashDelta.pm \
+              /usr/libdata/perl5/Unicode/Collate/Locale/bg.pl    \
+              /usr/libdata/perl5/Unicode/Collate/Locale/fr.pl    \
+              /usr/libdata/perl5/Unicode/Collate/Locale/ru.pl    \
+              /usr/libdata/perl5/unicore/lib/Sc/Cham.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Ethi.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Hebr.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Hmng.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Khar.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Khmr.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Lana.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Lao.pl           \
+              /usr/libdata/perl5/unicore/lib/Sc/Talu.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Tibt.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Xsux.pl          \
+              /usr/libdata/perl5/unicore/lib/Sc/Zzzz.pl          \
+              /usr/share/man/man1/c2ph.1                         \
+              /usr/share/man/man1/pstruct.1                      \
+              /usr/share/man/man3p/Locale::Codes::API.3p
+/usr/bin/c2ph
+/usr/bin/pstruct
+/usr/libdata/perl5/Locale/Codes/API.pod
+/usr/libdata/perl5/Module/CoreList/TieHashDelta.pm
+/usr/libdata/perl5/Unicode/Collate/Locale/bg.pl
+/usr/libdata/perl5/Unicode/Collate/Locale/fr.pl
+/usr/libdata/perl5/Unicode/Collate/Locale/ru.pl
+/usr/libdata/perl5/unicore/lib/Sc/Cham.pl
+/usr/libdata/perl5/unicore/lib/Sc/Ethi.pl
+/usr/libdata/perl5/unicore/lib/Sc/Hebr.pl
+/usr/libdata/perl5/unicore/lib/Sc/Hmng.pl
+/usr/libdata/perl5/unicore/lib/Sc/Khar.pl
+/usr/libdata/perl5/unicore/lib/Sc/Khmr.pl
+/usr/libdata/perl5/unicore/lib/Sc/Lana.pl
+/usr/libdata/perl5/unicore/lib/Sc/Lao.pl
+/usr/libdata/perl5/unicore/lib/Sc/Talu.pl
+/usr/libdata/perl5/unicore/lib/Sc/Tibt.pl
+/usr/libdata/perl5/unicore/lib/Sc/Xsux.pl
+/usr/libdata/perl5/unicore/lib/Sc/Zzzz.pl
+/usr/share/man/man1/c2ph.1
+/usr/share/man/man1/pstruct.1
+/usr/share/man/man3p/Locale::Codes::API.3p
+```
+
+Perform actions from the previous section &ndash; subsections **(g)** to **(k)**, then:
+
+After reboot into the upgraded system...
+
+```
+OpenBSD 6.5 (GENERIC.MP) #3: Sat Apr 13 14:48:43 MDT 2019
+
+Welcome to OpenBSD: The proactively secure Unix-like operating system.
+
+Please use the sendbug(1) utility to report bugs in the system.
+Before reporting a bug, please try to reproduce it with the latest
+version of the code.  With bug reports, please try to ensure that
+enough information to reproduce the problem is enclosed, and if a
+known fix for it exists, include that as well.
+```
+
+...and making initial network configuration...
+
+```
+$ sudo ifconfig vio0 10.0.2.101/24
+$ sudo route add default 10.0.2.1
+add net default: gateway 10.0.2.1
+```
+
+...it's the time to upgrade the packages: `$ sudo pkg_add -uv`; but first check the package database:
+
+```
+$ pkg_info
+perl:/usr/local/libdata/perl5/site_perl/amd64-openbsd/auto/Cwd/Cwd.so: undefined symbol 'PL_sv_undef'
+Can't load '/usr/local/libdata/perl5/site_perl/amd64-openbsd/auto/Cwd/Cwd.so' for module Cwd: Cannot load specified object at /usr/local/libdata/perl5/site_perl/amd64-openbsd/XSLoader.pm line 96.
+ at /usr/local/libdata/perl5/site_perl/amd64-openbsd/Cwd.pm line 82.
+Compilation failed in require at /usr/local/libdata/perl5/site_perl/amd64-openbsd/File/Spec/Unix.pm line 4.
+BEGIN failed--compilation aborted at /usr/local/libdata/perl5/site_perl/amd64-openbsd/File/Spec/Unix.pm line 4.
+Compilation failed in require at /usr/local/libdata/perl5/site_perl/amd64-openbsd/File/Spec.pm line 21.
+Compilation failed in require at /usr/libdata/perl5/OpenBSD/PackageInfo.pm line 168.
+```
+
+The command above doesn't work, and as it is clearly seeing in the output, something gets wrong with the Perl module `Cwd`. But further investigations show out that this module (as being an XS-module) was compiled to use with the previous version of Perl, hence it is incompatible with the currently installed Perl release.
+
+Obviously, the easiest solution to repair this crucial Perl module is to replace the whole Perl base module set with that one freshly downloaded from the OpenBSD CDN. It is contained in the `base65.tgz` tarball. The following compound one-liner command will replace the old Perl base module set with the new one with minimal effort from the user side:
+
+```
+$ mkdir        xyz                                                                                  && \
+  cd           xyz/                                                                                 && \
+  curl    -sO  https://cdn.openbsd.org/pub/OpenBSD/6.5/amd64/base65.tgz                             && \
+  tar     -xzf base65.tgz                                                                           && \
+  sudo rm -Rf  /usr/local/libdata/perl5/site_perl/amd64-openbsd/*                                   && \
+  sudo cp -Rf ./usr/libdata/perl5/amd64-openbsd/* /usr/local/libdata/perl5/site_perl/amd64-openbsd/ && \
+  cd -                                                                                              && \
+  sudo rm -Rf  xyz/
+```
+
+Now package-manipulation commands (`pkg_info`, `pkg_add`, `pkg_delete`, etc.) should be working fine:
+
+```
+$ pkg_info
+adwaita-icon-theme-3.28.0p1 base icon theme for GNOME
+at-spi2-atk-2.26.2  atk-bridge for at-spi2
+at-spi2-core-2.28.0p0 service interface for assistive technologies
+...
+xz-5.2.4            LZMA compression and decompression tools
+zip-3.0p0           create/update ZIP files compatible with PKZip(tm)
+zstd-1.3.5p0        zstandard fast real-time compression algorithm
+```
+
+Upgrade the packages:
+
+```
+$ sudo pkg_add -uv
+Update candidates: quirks-3.16 -> quirks-3.124
+quirks-3.124 signed on 2019-04-15T12:10:16Z
+quirks-3.16->3.124: ok
+Update candidates: adwaita-icon-theme-3.28.0p1 -> adwaita-icon-theme-3.30.1
+Update candidates: gtk-update-icon-cache-3.22.30p1 -> gtk-update-icon-cache-3.24.7
+Update candidates: gdk-pixbuf-2.36.12 -> gdk-pixbuf-2.38.1
+...
+Running tags: ok
+Read shared items: ok
+...
+Couldn't find updates for rebar19-2.6.2p0
+Extracted 2530483626 from 2530564521
+```
+Make all the necessary removals and updates which were reported by the `pkg_add` command:
+
+```
+$ sudo rm -f /var/db/colord/mapping.db \
+             /var/db/colord/storage.db
+$
+$ sudo rm -rf /etc/dconf/db/*      \
+              /etc/dconf/profile/*
+$
+$ sudo xmlcatalog /var/db/xmlcatalog
+$
+$ sudo update-desktop-database
+$
+$ sudo update-mime-database /usr/local/share/mime/
+```
+
+Perform the action from the previous section, subsection **(m)**.
+
+**== OPENBSD HAS BEEN UPGRADED TO THE 6.5 RELEASE ==**
 
 Freshly **OpenBSD**-ing your beings ! :+1:

--- a/src/data/docs/openbsd/upgrade-63-to-65.md
+++ b/src/data/docs/openbsd/upgrade-63-to-65.md
@@ -1,0 +1,15 @@
+# Upgrade OpenBSD 6.3 to 6.5
+
+### OpenBSD/amd64 6.3 to 6.5 Upgrade Instructions
+
+As clearly stated in the OpenBSD FAQ regarding upgrading one release to another, *upgrades are only supported from one release to the release immediately following it*. So what to do if it needs to upgrade the 6.3 release of OpenBSD to the 6.5 release is to upgrade sequentially, first to the 6.4 release, and then to the 6.5 release.
+
+**Upgrade OpenBSD 6.3 release to 6.4 release**
+
+TBD.
+
+**Upgrade OpenBSD 6.4 release to 6.5 release**
+
+TBD.
+
+Freshly **OpenBSD**-ing your beings ! :+1:

--- a/src/data/docs/openbsd/upgrade-63-to-65.md
+++ b/src/data/docs/openbsd/upgrade-63-to-65.md
@@ -6,7 +6,192 @@ As clearly stated in the OpenBSD FAQ regarding upgrading one release to another,
 
 **Upgrade OpenBSD 6.3 release to 6.4 release**
 
-TBD.
+Having installed and running the OpenBSD/amd64 6.3 release first of all it needs to download the new (6.4) ramdisk kernel `bsd.rd` and the checksum file `SHA256.sig` for the appropriate architecture, in this case `amd64`:
+
+```
+$ curl -sO https://cdn.openbsd.org/pub/OpenBSD/6.4/amd64/bsd.rd     \
+       -sO https://cdn.openbsd.org/pub/OpenBSD/6.4/amd64/SHA256.sig
+```
+
+Verify checksum of the new ramdisk kernel:
+
+```
+$ signify -C -p /etc/signify/openbsd-64-base.pub -x SHA256.sig bsd.rd
+Signature Verified
+bsd.rd: OK
+```
+
+Permanently set the new CDN URL (it was changed in the 6.4 release) which will be used during system upgrade and later on during upgrading the packages:
+
+```
+$ cat /etc/installurl
+https://ftp.openbsd.org/pub/OpenBSD    <== The old one.
+$
+$ sudo su -
+# echo "https://cdn.openbsd.org/pub/OpenBSD" > /etc/installurl
+$
+$ cat /etc/installurl
+https://cdn.openbsd.org/pub/OpenBSD    <== The new one.
+```
+
+Remove unneeded (unused) files:
+
+```
+$ sudo rm -vf /dev/audio /dev/audioctl
+/dev/audio
+/dev/audioctl
+$
+$ sudo rm -vf /etc/rc.d/rtadvd /usr/sbin/rtadvd \
+              /usr/share/man/man5/rtadvd.conf.5 \
+              /usr/share/man/man8/rtadvd.8
+/etc/rc.d/rtadvd
+/usr/sbin/rtadvd
+/usr/share/man/man5/rtadvd.conf.5
+/usr/share/man/man8/rtadvd.8
+$
+$ sudo rm -vf /usr/X11R6/lib/libxcb-xevie.*          \
+              /usr/X11R6/lib/libxcb-xprint.*         \
+              /usr/X11R6/lib/pkgconfig/xcb-xevie.pc  \
+              /usr/X11R6/lib/pkgconfig/xcb-xprint.pc
+/usr/X11R6/lib/libxcb-xevie.a
+/usr/X11R6/lib/libxcb-xevie.so.1.0
+/usr/X11R6/lib/libxcb-xprint.a
+/usr/X11R6/lib/libxcb-xprint.so.3.0
+/usr/X11R6/lib/pkgconfig/xcb-xevie.pc
+/usr/X11R6/lib/pkgconfig/xcb-xprint.pc
+```
+
+Remove unneeded (unused) user and group:
+
+```
+$ sudo userdel _rtadvd && sudo groupdel _rtadvd
+```
+
+Disable starting up the `buildslave` (obsolete) daemon:
+
+```
+$ sudo rcctl disable buildslave
+```
+
+Copy the new ramdisk kernel to the root filesystem:
+
+```
+$ sudo cp -vf bsd.rd /
+bsd.rd -> /bsd.rd
+```
+
+**== IT'S THE TIME TO BOOT INTO THE NEW KERNEL ==**
+
+Reboot:
+
+```
+$ sudo shutdown -r now
+```
+
+At the boot loader prompt type `bsd.rd` and hit `<Enter>`:
+
+```
+boot> bsd.rd
+```
+
+After the kernel is booted, hit `s` (that means `(S)hell`) to enter the shell to configure network if not already autoconfigured. In the shell make necessary network configuration, then hit `<Ctrl-D>` to return to the installation/upgrading program. (This step is very important if, for example, the OpenBSD box is installed and running as a virtual machine, like [this one](https://github.com/rgolubtsov/dotfiles/blob/master/openbsd/README.md "OpenBSD VM-boxes using QEMU")):
+
+```
+# ifconfig vio0 10.0.2.101/24
+# route add default 10.0.2.1
+add net default: gateway 10.0.2.1
+# ^D
+```
+
+Hit `u` (that means `(U)pgrade`) and follow sequential prompts. In most cases for most questions just hit `<Enter>` for default choices.
+
+After reboot into the upgraded system...
+
+```
+OpenBSD 6.4 (GENERIC.MP) #364: Thu Oct 11 13:30:23 MDT 2018
+
+Welcome to OpenBSD: The proactively secure Unix-like operating system.
+
+Please use the sendbug(1) utility to report bugs in the system.
+Before reporting a bug, please try to reproduce it with the latest
+version of the code.  With bug reports, please try to ensure that
+enough information to reproduce the problem is enclosed, and if a
+known fix for it exists, include that as well.
+```
+
+...and making initial network configuration...
+
+```
+$ sudo ifconfig vio0 10.0.2.101/24
+$ sudo route add default 10.0.2.1
+add net default: gateway 10.0.2.1
+```
+
+...upgrade the packages:
+
+```
+$ sudo pkg_add -uv
+Update candidates: quirks-2.414 -> quirks-3.16
+quirks-3.16 signed on 2018-10-12T15:26:25Z
+quirks-2.414->3.16: ok
+Update candidates: adwaita-icon-theme-3.26.1 -> adwaita-icon-theme-3.28.0p1
+Update candidates: gtk-update-icon-cache-3.22.29 -> gtk-update-icon-cache-3.22.30p1
+Update candidates: hicolor-icon-theme-0.17 -> hicolor-icon-theme-0.17
+...
+Running tags: ok
+Read shared items: ok
+...
+Obsolete package: mozjs17-17.0p4 (no longer maintained and full of security holes)
+Couldn't find updates for mozjs17-17.0p4
+Extracted 2124668768 from 2265411565
+```
+
+Make all the necessary removals and updates which were reported by the `pkg_add` command:
+
+```
+$ sudo rm -f /var/db/colord/mapping.db \
+             /var/db/colord/storage.db
+$
+$ sudo rm -rf /etc/dconf/db/*      \
+              /etc/dconf/profile/*
+$
+$ sudo rm -Rf /usr/local/lib/gcc/x86_64-unknown-openbsd6.3/
+$
+$ sudo rm -Rf /usr/local/share/mime/x-epoc/      \
+              /usr/local/share/mime/x-content/   \
+              /usr/local/share/mime/video/       \
+              /usr/local/share/mime/text/        \
+              /usr/local/share/mime/multipart/   \
+              /usr/local/share/mime/model/       \
+              /usr/local/share/mime/message/     \
+              /usr/local/share/mime/inode/       \
+              /usr/local/share/mime/image/       \
+              /usr/local/share/mime/font/        \
+              /usr/local/share/mime/audio/       \
+              /usr/local/share/mime/application/
+$
+$ sudo xmlcatalog /var/db/xmlcatalog
+$
+$ sudo update-desktop-database
+$
+$ sudo update-mime-database /usr/local/share/mime/
+$
+$ sudo pkg_delete -v mozjs17
+mozjs17-17.0p4: ok
+Read shared items: ok
+```
+
+Remove previously downloaded and already unneeded ramdisk kernel and its checksum file which reside in the user home directory:
+
+```
+$ rm -vf bsd.rd SHA256.sig 
+bsd.rd
+SHA256.sig
+```
+
+**== OPENBSD HAS BEEN UPGRADED TO THE 6.4 RELEASE ==**
+
+:smiley:
 
 **Upgrade OpenBSD 6.4 release to 6.5 release**
 


### PR DESCRIPTION
- Populating the **Markdown** document with the instructions on how to upgrade **OpenBSD** 6.3 release to 6.4 release.
- Adding document metadata for **Harp** postprocessing.
- Generating the **HTML** document from its **Markdown** source.