### PR TITLE
CSS: Get rid of extra gap on wide screens.

### DIFF
--- a/radicchio.css
+++ b/radicchio.css
@@ -163,7 +163,6 @@ pre {
 
 #stat-cont {
     margin:           5px 28px 18px;
-    border-right:     1px solid #4ca419;
     border-left:      1px solid #4ca419;
     overflow:         auto;
 }


### PR DESCRIPTION
- Removing an extra vertical gap between right-side outer table border and table cells' right edge borders. This is very distinctly viewable on wide (or normal) screens.