### PR TITLE
CV in HTML: Reorganize preambles, add initial sections.

### DIFF
--- a/data/docs/cv/cv_en_us.html
+++ b/data/docs/cv/cv_en_us.html
@@ -50,12 +50,36 @@
 
 <h1>Curriculum Vitae</h1>
 <h3>OBJECTIVE: To obtain the position of a Software Developer / Senior Software Developer</h3>
-<p>Total IT experience &ndash; 20+ years | An IT multilinguist</p>
+<p>An IT multilinguist</p>
 <p>The content is under construction. Please wait for a while... <img src="https://github.githubassets.com/images/icons/emoji/unicode/1f64b.png" class="emoji" alt="" /></p>
 <div   id="cv-cont">
 <table id="cv-table0">
 <tbody>
 <tr>
+<td colspan="2">SUMMARY</td>
+</tr>
+<tr>
+<td colspan="2">Total IT experience &ndash; 20+ years</td>
+</tr>
+<tr>
+<td>Hardware</td>
+<td><ul>
+<li>Intel x86 (i686 / x86-64)</li>
+<li>HP PA-RISC</li>
+<li>IBM PowerPC</li>
+<li>Sun SPARCstation</li>
+</ul></td>
+</tr>
+<tr>
+<td>Operating<br />Systems</td>
+<td>Unices and derivatives (OpenBSD, FreeBSD, Arch Linux, Debian GNU/Linux, Ubuntu, Fedora, CentOS, Red Hat Enterprise Linux, Mac OS X, HP-UX, IBM AIX, Sun Solaris). Microsoft Windows</td>
+</tr>
+<tr>
+<td>Programming<br />Languages</td>
+<td>Java, Clojure, Perl 5, Python, Bash Shell Script, JavaScript (ES5-6/Node.js), C, Go, GNOME Vala/Genie, Lua, C++,Objective-C, Fortran 95, Erlang, Elixir, LFE (Lisp Flavoured Erlang)</td>
+</tr>
+<tr>
+<td>Technologies</td>
 <td><img src="https://github.githubassets.com/images/icons/emoji/unicode/1f603.png" class="emoji" alt="" /></td>
 </tr>
 </tbody>

--- a/data/docs/cv/cv_ru_ru.html
+++ b/data/docs/cv/cv_ru_ru.html
@@ -50,12 +50,36 @@
 
 <h1>Curriculum Vitae</h1>
 <h3>ЦЕЛЬ: Получить должность Software Developer / Senior Software Developer</h3>
-<p>Суммарный опыт работы в сфере ИТ &ndash; более 20 лет | IT-мультилингвист</p>
+<p>IT-мультилингвист</p>
 <p>Страница находится в разработке. Пожалуйста, подождите немного... <img src="https://github.githubassets.com/images/icons/emoji/unicode/1f64b.png" class="emoji" alt="" /></p>
 <div   id="cv-cont">
 <table id="cv-table0">
 <tbody>
 <tr>
+<td colspan="2">РЕЗЮМЕ</td>
+</tr>
+<tr>
+<td colspan="2">Суммарный опыт работы в сфере ИТ &ndash; более 20 лет</td>
+</tr>
+<tr>
+<td>Вычислительные<br />платформы</td>
+<td><ul>
+<li>Intel x86 (i686 / x86-64)</li>
+<li>HP PA-RISC</li>
+<li>IBM PowerPC</li>
+<li>Sun SPARCstation</li>
+</ul></td>
+</tr>
+<tr>
+<td>Операционные<br />системы</td>
+<td>Юниксы и их производные (OpenBSD, FreeBSD, Arch Linux, Debian GNU/Linux, Ubuntu, Fedora, CentOS, Red Hat Enterprise Linux, Mac OS X, HP-UX, IBM AIX, Sun Solaris). Microsoft Windows</td>
+</tr>
+<tr>
+<td>Языки<br />программирования</td>
+<td>Java, Clojure, Perl 5, Python, Bash Shell Script, JavaScript (ES5-6/Node.js), C, Go, GNOME Vala/Genie, Lua, C++,Objective-C, Fortran 95, Erlang, Elixir, LFE (Lisp Flavoured Erlang)</td>
+</tr>
+<tr>
+<td>Технологии</td>
 <td><img src="https://github.githubassets.com/images/icons/emoji/unicode/1f603.png" class="emoji" alt="" /></td>
 </tr>
 </tbody>

--- a/src/data/docs/cv/_data.json
+++ b/src/data/docs/cv/_data.json
@@ -4,17 +4,15 @@
         "sitename_" : ": Curriculum Vitae",
         "subtitle_" : "",
         "subtitle3" : "OBJECTIVE: To obtain the position of a Software Developer / Senior Software Developer",
-        "preamble1" : "Total IT experience &ndash; 20+ years",
-        "preamble2" : "An IT multilinguist",
-        "preamble3" : "The content is under construction. Please wait for a while... :raising_hand:"
+        "preamble1" : "An IT multilinguist",
+        "preamble2" : "The content is under construction. Please wait for a while... :raising_hand:"
     },
     "cv_ru_ru"      : {
         "layout"    : "../../../_radicchio",
         "sitename_" : ": Curriculum Vitae",
         "subtitle_" : "",
         "subtitle3" : "ЦЕЛЬ: Получить должность Software Developer / Senior Software Developer",
-        "preamble1" : "Суммарный опыт работы в сфере ИТ &ndash; более 20 лет",
-        "preamble2" : "IT-мультилингвист",
-        "preamble3" : "Страница находится в разработке. Пожалуйста, подождите немного... :raising_hand:"
+        "preamble1" : "IT-мультилингвист",
+        "preamble2" : "Страница находится в разработке. Пожалуйста, подождите немного... :raising_hand:"
     }
 }

--- a/src/data/docs/cv/cv_en_us.ejs
+++ b/src/data/docs/cv/cv_en_us.ejs
@@ -4,12 +4,36 @@
 
 <h1><%= cv_en_us.sitename_.substring(2) %></h1>
 <h3><%= cv_en_us.subtitle3              %></h3>
-<p><%-  cv_en_us.preamble1 %> | <%= cv_en_us.preamble2 %></p>
-<p><%-  cv_en_us.preamble3 %></p>
+<p><%=  cv_en_us.preamble1 %></p>
+<p><%=  cv_en_us.preamble2 %></p>
 <div   id="cv-cont">
 <table id="cv-table0">
 <tbody>
 <tr>
+<td colspan="2">SUMMARY</td>
+</tr>
+<tr>
+<td colspan="2">Total IT experience &ndash; 20+ years</td>
+</tr>
+<tr>
+<td>Hardware</td>
+<td><ul>
+<li>Intel x86 (i686 / x86-64)</li>
+<li>HP PA-RISC</li>
+<li>IBM PowerPC</li>
+<li>Sun SPARCstation</li>
+</ul></td>
+</tr>
+<tr>
+<td>Operating<br />Systems</td>
+<td>Unices and derivatives (OpenBSD, FreeBSD, Arch Linux, Debian GNU/Linux, Ubuntu, Fedora, CentOS, Red Hat Enterprise Linux, Mac OS X, HP-UX, IBM AIX, Sun Solaris). Microsoft Windows</td>
+</tr>
+<tr>
+<td>Programming<br />Languages</td>
+<td>Java, Clojure, Perl 5, Python, Bash Shell Script, JavaScript (ES5-6/Node.js), C, Go, GNOME Vala/Genie, Lua, C++,Objective-C, Fortran 95, Erlang, Elixir, LFE (Lisp Flavoured Erlang)</td>
+</tr>
+<tr>
+<td>Technologies</td>
 <td>:smiley:</td>
 </tr>
 </tbody>

--- a/src/data/docs/cv/cv_ru_ru.ejs
+++ b/src/data/docs/cv/cv_ru_ru.ejs
@@ -4,12 +4,36 @@
 
 <h1><%= cv_ru_ru.sitename_.substring(2) %></h1>
 <h3><%= cv_ru_ru.subtitle3              %></h3>
-<p><%-  cv_ru_ru.preamble1 %> | <%= cv_ru_ru.preamble2 %></p>
-<p><%-  cv_ru_ru.preamble3 %></p>
+<p><%=  cv_ru_ru.preamble1 %></p>
+<p><%=  cv_ru_ru.preamble2 %></p>
 <div   id="cv-cont">
 <table id="cv-table0">
 <tbody>
 <tr>
+<td colspan="2">РЕЗЮМЕ</td>
+</tr>
+<tr>
+<td colspan="2">Суммарный опыт работы в сфере ИТ &ndash; более 20 лет</td>
+</tr>
+<tr>
+<td>Вычислительные<br />платформы</td>
+<td><ul>
+<li>Intel x86 (i686 / x86-64)</li>
+<li>HP PA-RISC</li>
+<li>IBM PowerPC</li>
+<li>Sun SPARCstation</li>
+</ul></td>
+</tr>
+<tr>
+<td>Операционные<br />системы</td>
+<td>Юниксы и их производные (OpenBSD, FreeBSD, Arch Linux, Debian GNU/Linux, Ubuntu, Fedora, CentOS, Red Hat Enterprise Linux, Mac OS X, HP-UX, IBM AIX, Sun Solaris). Microsoft Windows</td>
+</tr>
+<tr>
+<td>Языки<br />программирования</td>
+<td>Java, Clojure, Perl 5, Python, Bash Shell Script, JavaScript (ES5-6/Node.js), C, Go, GNOME Vala/Genie, Lua, C++,Objective-C, Fortran 95, Erlang, Elixir, LFE (Lisp Flavoured Erlang)</td>
+</tr>
+<tr>
+<td>Технологии</td>
 <td>:smiley:</td>
 </tr>
 </tbody>


### PR DESCRIPTION
- Bringing out a one of preambles from metadata into EJSes.
- Reorganizing preambles, adding "SUMMARY", "Hardware", "Operating Systems", and "Programming Languages" sections.